### PR TITLE
Fix currency display as '1'

### DIFF
--- a/Controller/AbstractDeliveryOptions.php
+++ b/Controller/AbstractDeliveryOptions.php
@@ -159,8 +159,9 @@ abstract class AbstractDeliveryOptions extends Action
             $googleapikey,
             $defaultShippingCost,
             $language,
-            $showZeroCostsAsFree,
-            $currencySymbol
+            $currencySymbol,
+            false,
+            $showZeroCostsAsFree
         );
 
         $settings->setExcludeShippingDiscount(false);


### PR DESCRIPTION
Incorrect parameters count applied in the settings making currency symbol to fall under different variable.
```
    public function __construct(
        string $origin,
        string $user,
        string $password,
        bool $pickupPointsEnabled,
        int $maxPickupPoints,
        string $googleKey,
        float $defaultCosts,
        ?string $webshopLanguage = 'nl-NL',
        string $currency = '€', 
        bool $excludeShippingDiscount = false, 
        bool $showZeroCostsAsFree = false)
    {
```
vs 
```
            $webshop,
            $username,
            $password,
            !$disabledPickupPoints,
            $maxPickupPoints,
            $googleapikey,
            $defaultShippingCost,
            $language,
            $showZeroCostsAsFree,
            $currencySymbol
```