### PR TITLE
Feature/19109 diagnostics

### DIFF
--- a/Controller/AbstractDeliveryOptions.php
+++ b/Controller/AbstractDeliveryOptions.php
@@ -7,10 +7,10 @@ use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Locale\CurrencyInterface;
-use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Monta\CheckoutApiWrapper\MontapackingShipping as MontpackingApi;
 use Monta\CheckoutApiWrapper\Objects\Settings;
+use Montapacking\MontaCheckout\Helper\System;
 use Montapacking\MontaCheckout\Model\Config\Provider\Carrier as CarrierConfig;
 
 abstract class AbstractDeliveryOptions extends Action
@@ -29,13 +29,15 @@ abstract class AbstractDeliveryOptions extends Action
      * @param Cart $cart
      * @param StoreManagerInterface $storeManager
      * @param CurrencyInterface $currencyInterface
+     * @param System $systemHelper
      */
     public function __construct(
         Context $context,
         CarrierConfig $carrierConfig,
         Cart $cart,
         StoreManagerInterface $storeManager,
-        CurrencyInterface $currencyInterface
+        CurrencyInterface $currencyInterface,
+        protected readonly System $systemHelper,
     )
     {
         $this->carrierConfig = $carrierConfig;
@@ -44,9 +46,7 @@ abstract class AbstractDeliveryOptions extends Action
         $this->storeManager = $storeManager;
         $this->currency = $currencyInterface;
 
-        parent::__construct(
-            $context
-        );
+        parent::__construct($context);
     }
 
     /**

--- a/Controller/AbstractDeliveryOptions.php
+++ b/Controller/AbstractDeliveryOptions.php
@@ -177,6 +177,7 @@ abstract class AbstractDeliveryOptions extends Action
         );
 
         $settings->setExcludeShippingDiscount(false);
+        $settings->setSystemInfo($this->systemHelper->getInfo());
 
         $oApi = new MontpackingApi($settings, $language);
         $oApi->setAddress($street, $housenumber, $housenumberaddition, $postcode, $city, $state, $country);

--- a/Controller/DeliveryOptions/Delivery.php
+++ b/Controller/DeliveryOptions/Delivery.php
@@ -16,6 +16,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Montapacking\MontaCheckout\Controller\AbstractDeliveryOptions;
 use Montapacking\MontaCheckout\Helper\DeliveryHelper;
 use Montapacking\MontaCheckout\Helper\PickupHelper;
+use Montapacking\MontaCheckout\Helper\System;
 use Montapacking\MontaCheckout\Logger\Logger;
 use Montapacking\MontaCheckout\Model\Config\Provider\Carrier as CarrierConfig;
 
@@ -67,6 +68,7 @@ class Delivery extends AbstractDeliveryOptions
      * @param DeliveryHelper $deliveryHelper
      * @param StoreManagerInterface $storeManager
      * @param CurrencyInterface $currencyInterface
+     * @param System $systemHelper
      */
     public function __construct(
         Context $context,
@@ -78,7 +80,8 @@ class Delivery extends AbstractDeliveryOptions
         PickupHelper $pickupHelper,
         DeliveryHelper $deliveryHelper,
         StoreManagerInterface $storeManager,
-        CurrencyInterface $currencyInterface
+        CurrencyInterface $currencyInterface,
+        System $systemHelper,
     )
     {
         $this->_logger = $logger;
@@ -95,7 +98,8 @@ class Delivery extends AbstractDeliveryOptions
             $carrierConfig,
             $cart,
             $storeManager,
-            $currencyInterface
+            $currencyInterface,
+            $systemHelper
         );
     }
 

--- a/Controller/DeliveryOptions/LongLat.php
+++ b/Controller/DeliveryOptions/LongLat.php
@@ -11,6 +11,7 @@ use Magento\Framework\Locale\CurrencyInterface;
 use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Store\Model\StoreManagerInterface;
 use Montapacking\MontaCheckout\Controller\AbstractDeliveryOptions;
+use Montapacking\MontaCheckout\Helper\System;
 use Montapacking\MontaCheckout\Logger\Logger;
 use Montapacking\MontaCheckout\Model\Config\Provider\Carrier as CarrierConfig;
 
@@ -48,6 +49,7 @@ class LongLat extends AbstractDeliveryOptions
      * @param Cart $cart
      * @param StoreManagerInterface $storeManager
      * @param CurrencyInterface $currencyInterface
+     * @param System $systemHelper
      */
     public function __construct(
         Context $context,
@@ -56,7 +58,8 @@ class LongLat extends AbstractDeliveryOptions
         Logger $logger,
         Cart $cart,
         StoreManagerInterface $storeManager,
-        CurrencyInterface $currencyInterface
+        CurrencyInterface $currencyInterface,
+        System $systemHelper,
     )
     {
         $this->_logger = $logger;
@@ -70,7 +73,8 @@ class LongLat extends AbstractDeliveryOptions
             $carrierConfig,
             $cart,
             $storeManager,
-            $currencyInterface
+            $currencyInterface,
+            $systemHelper
         );
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Montapacking\MontaCheckout\Helper;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -14,29 +13,32 @@ class Data extends AbstractHelper
      */
     protected $directoryList;
 
+    /**
+     * @param Context $context
+     * @param DirectoryList $directoryList
+     */
     public function __construct(
         Context $context,
         DirectoryList $directoryList
     )
     {
         $this->directoryList = $directoryList;
-        parent::__construct(
-            $context
-        );
+        parent::__construct($context);
     }
 
-    /**
-     * Get path to var/log directory
+    /** Get path to requested directory
      *
-     * @return string
+     * @param string $directory
+     * @return string - absolute system path
      * @throws FileSystemException
      */
-    public function getPath()
+    public function getPath($directory = 'log')
     {
-        return $this->directoryList->getPath('log');
+        return $this->directoryList->getPath($directory);
     }
 
     /**
+     * @param $path
      * @return array
      */
     protected function getLogFiles($path)
@@ -60,8 +62,8 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param     $bytes
-     * @param int $precision
+     * @param $bytes
+     * @param $precision
      * @return string
      */
     protected function filesizeToReadableString($bytes, $precision = 2)
@@ -104,13 +106,23 @@ class Data extends AbstractHelper
         return array_slice($logFileData, 0, $maxNumOfLogs);
     }
 
+    /**
+     * @param $fileName
+     * @param $numOfLines
+     * @return string
+     */
     public function getLastLinesOfFile($fileName, $numOfLines)
     {
         $lines = $this->tailExec($fileName, $numOfLines);
         return implode('', $lines);
     }
 
-    public function tailExec($file, $lines)
+    /**
+     * @param $file
+     * @param $lines
+     * @return array
+     */
+    protected function tailExec($file, $lines)
     {
         //global $fsize;
         $handle = fopen($file, "r");

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -27,13 +27,13 @@ class System extends AbstractHelper
     {
         $moduleName = $this->_getModuleName();
         return [
-            'core_software' => 'Magento',
-            'core_version' => InstalledVersions::getVersion('magento/product-community-edition'),
-            'checkout_api_wrapper_version' => InstalledVersions::getVersion('monta/checkout-api-wrapper'),
-            'module_name' => $moduleName,
-            'module_version' => $this->resource->getDbVersion($moduleName),
-            'php_version' => PHP_VERSION,
-            'operating_system' => PHP_OS,
+            'coreSoftware' => 'Magento',
+            'coreVersion' => InstalledVersions::getVersion('magento/product-community-edition'),
+            'checkoutApiWrapperVersion' => InstalledVersions::getVersion('monta/checkout-api-wrapper'),
+            'moduleName' => $moduleName,
+            'moduleVersion' => $this->resource->getDbVersion($moduleName),
+            'phpVersion' => PHP_VERSION,
+            'operatingSystem' => PHP_OS,
         ];
     }
 }

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -44,6 +44,11 @@ class System extends AbstractHelper
      */
     protected function getComposerVersion(string $packageName): string
     {
-        return InstalledVersions::getVersion($packageName);
+        try {
+            return InstalledVersions::getVersion($packageName);
+        } catch (\OutOfBoundsException $e) {
+            // When module not installed, catch error and return empty string
+            return "";
+        }
     }
 }

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -28,13 +28,22 @@ class System extends AbstractHelper
         $moduleName = $this->_getModuleName();
         return [
             'coreSoftware' => 'Magento',
-            'coreVersion' => InstalledVersions::getVersion('magento/product-community-edition'),
-            'frameworkVersion' => InstalledVersions::getVersion('magento/framework'),
-            'checkoutApiWrapperVersion' => InstalledVersions::getVersion('monta/checkout-api-wrapper'),
+            'coreVersion' => $this->getComposerVersion('magento/product-community-edition'),
+            'frameworkVersion' => $this->getComposerVersion('magento/framework'),
+            'checkoutApiWrapperVersion' => $this->getComposerVersion('monta/checkout-api-wrapper'),
             'moduleName' => $moduleName,
             'moduleVersion' => $this->resource->getDbVersion($moduleName),
             'phpVersion' => PHP_VERSION,
             'operatingSystem' => PHP_OS,
         ];
+    }
+
+    /**
+     * @param string $packageName
+     * @return string
+     */
+    protected function getComposerVersion(string $packageName): string
+    {
+        return InstalledVersions::getVersion($packageName);
     }
 }

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -33,8 +33,6 @@ class System extends AbstractHelper
             Settings::CHECKOUT_API_WRAPPER_VERSION => $this->getComposerVersion('monta/checkout-api-wrapper'),
             Settings::MODULE_NAME => $moduleName,
             Settings::MODULE_VERSION => $this->resource->getDbVersion($moduleName),
-            Settings::PHP_VERSION => PHP_VERSION,
-            Settings::OPERATING_SYSTEM => PHP_OS,
         ];
     }
 

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -23,12 +23,13 @@ class System extends AbstractHelper
      *
      * @return string[]
      */
-    public function getDiagnostics()
+    public function getInfo(): array
     {
         $moduleName = $this->_getModuleName();
         return [
             'coreSoftware' => 'Magento',
             'coreVersion' => InstalledVersions::getVersion('magento/product-community-edition'),
+            'frameworkVersion' => InstalledVersions::getVersion('magento/framework'),
             'checkoutApiWrapperVersion' => InstalledVersions::getVersion('monta/checkout-api-wrapper'),
             'moduleName' => $moduleName,
             'moduleVersion' => $this->resource->getDbVersion($moduleName),

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -8,6 +8,7 @@ namespace Montapacking\MontaCheckout\Helper;
 use Composer\InstalledVersions;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\Module\ResourceInterface;
+use Monta\CheckoutApiWrapper\Objects\Settings;
 
 class System extends AbstractHelper
 {
@@ -27,14 +28,13 @@ class System extends AbstractHelper
     {
         $moduleName = $this->_getModuleName();
         return [
-            'coreSoftware' => 'Magento',
-            'coreVersion' => $this->getComposerVersion('magento/product-community-edition'),
-            'frameworkVersion' => $this->getComposerVersion('magento/framework'),
-            'checkoutApiWrapperVersion' => $this->getComposerVersion('monta/checkout-api-wrapper'),
-            'moduleName' => $moduleName,
-            'moduleVersion' => $this->resource->getDbVersion($moduleName),
-            'phpVersion' => PHP_VERSION,
-            'operatingSystem' => PHP_OS,
+            Settings::CORE_SOFTWARE => 'Magento',
+            Settings::CORE_VERSION => $this->getComposerVersion('magento/product-community-edition'),
+            Settings::CHECKOUT_API_WRAPPER_VERSION => $this->getComposerVersion('monta/checkout-api-wrapper'),
+            Settings::MODULE_NAME => $moduleName,
+            Settings::MODULE_VERSION => $this->resource->getDbVersion($moduleName),
+            Settings::PHP_VERSION => PHP_VERSION,
+            Settings::OPERATING_SYSTEM => PHP_OS,
         ];
     }
 

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @author Jacco.Amersfoort <jacco.amersfoort@monta.nl>
+ * @created 5/14/2025 10:59
+ */
+namespace Montapacking\MontaCheckout\Helper;
+
+class System
+{
+    public function __construct()
+    {
+    }
+
+    public function getDiagnostics()
+    {
+        return [
+            'test' => "hello",
+        ];
+    }
+
+}

--- a/Helper/System.php
+++ b/Helper/System.php
@@ -5,17 +5,35 @@
  */
 namespace Montapacking\MontaCheckout\Helper;
 
-class System
+use Composer\InstalledVersions;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\Module\ResourceInterface;
+
+class System extends AbstractHelper
 {
-    public function __construct()
+    /**
+     * @param ResourceInterface $resource
+     */
+    public function __construct(
+        protected readonly ResourceInterface $resource)
     {
     }
 
+    /** Collect system information
+     *
+     * @return string[]
+     */
     public function getDiagnostics()
     {
+        $moduleName = $this->_getModuleName();
         return [
-            'test' => "hello",
+            'core_software' => 'Magento',
+            'core_version' => InstalledVersions::getVersion('magento/product-community-edition'),
+            'checkout_api_wrapper_version' => InstalledVersions::getVersion('monta/checkout-api-wrapper'),
+            'module_name' => $moduleName,
+            'module_version' => $this->resource->getDbVersion($moduleName),
+            'php_version' => PHP_VERSION,
+            'operating_system' => PHP_OS,
         ];
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "~7.1|~7.2|~7.3|~7.4|~8.1|~8.2|~8.3",
         "ext-json": "*",
-        "monta/checkout-api-wrapper": "^1.19"
+        "monta/checkout-api-wrapper": "^1.23"
     },
     "type": "magento2-module",
     "license": "CC-BY-NC-ND-3.0",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Montapacking_MontaCheckout" setup_version="2.1.0">
+    <module name="Montapacking_MontaCheckout" setup_version="2.1.1">
         <sequence>
             <module name="Magento_Checkout"/>
         </sequence>


### PR DESCRIPTION
- Add SystemInformation to checkout request, along the the _deliveryoptions/delivery_ call
- Gathers module version information about Magento, MontaCheckout and CheckoutApiWrapper. 
- Gathers PHP and OS information too as specified in the issue 
- Plus a little cleanup on other tangent code