### PR TITLE
Feature/version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "monta/montacheckout",
     "description": "Monta Checkout Extension",
     "require": {
-        "php": "~7.1|~7.2|~7.3|~7.4|~8.1|~8.2|~8.3",
+        "php": "~8.1|~8.2|~8.3",
         "ext-json": "*",
         "monta/checkout-api-wrapper": "^1.25"
     },

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Montapacking_MontaCheckout" setup_version="2.1.1">
+    <module name="Montapacking_MontaCheckout" setup_version="2.1.2">
         <sequence>
             <module name="Magento_Checkout"/>
         </sequence>


### PR DESCRIPTION
- Bump setup version one patch number 
- Drop PHP 7 requirements in Composer, since CheckoutApiWrapper already requires 8.1 so the module can already not be installed on PHP below 8